### PR TITLE
Add MAUI Blazor Hybrid POS interface layout

### DIFF
--- a/PosMultiplataforma.sln
+++ b/PosMultiplataforma.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34023.191
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PosMultiplataforma", "PosMultiplataforma\\PosMultiplataforma.csproj", "{BA1C4E6F-5E7F-4C5C-B6E0-6138596C9039}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {BA1C4E6F-5E7F-4C5C-B6E0-6138596C9039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {BA1C4E6F-5E7F-4C5C-B6E0-6138596C9039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {BA1C4E6F-5E7F-4C5C-B6E0-6138596C9039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {BA1C4E6F-5E7F-4C5C-B6E0-6138596C9039}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/PosMultiplataforma/App.xaml
+++ b/PosMultiplataforma/App.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="PosMultiplataforma.App">
+    <Application.Resources>
+        <!-- Resources can be added here -->
+    </Application.Resources>
+</Application>

--- a/PosMultiplataforma/App.xaml.cs
+++ b/PosMultiplataforma/App.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+
+namespace PosMultiplataforma;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+
+        MainPage = new MainPage();
+    }
+}

--- a/PosMultiplataforma/Main.razor
+++ b/PosMultiplataforma/Main.razor
@@ -1,0 +1,11 @@
+@* Router principal del proyecto Blazor Hybrid *@
+<Router AppAssembly="@typeof(Main).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Shared.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(Shared.MainLayout)">
+            <p role="alert">No se encontró el recurso solicitado.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/PosMultiplataforma/MainPage.xaml
+++ b/PosMultiplataforma/MainPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:PosMultiplataforma"
+             xmlns:blazor="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
+             x:Class="PosMultiplataforma.MainPage">
+    <BlazorWebView HostPage="wwwroot/index.html">
+        <BlazorWebView.RootComponents>
+            <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+        </BlazorWebView.RootComponents>
+    </BlazorWebView>
+</ContentPage>

--- a/PosMultiplataforma/MainPage.xaml.cs
+++ b/PosMultiplataforma/MainPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace PosMultiplataforma;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/PosMultiplataforma/MauiProgram.cs
+++ b/PosMultiplataforma/MauiProgram.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.Logging;
+
+namespace PosMultiplataforma;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+        builder.Services.AddMauiBlazorWebView();
+
+#if DEBUG
+        builder.Services.AddBlazorWebViewDeveloperTools();
+        builder.Logging.AddDebug();
+#endif
+
+        return builder.Build();
+    }
+}

--- a/PosMultiplataforma/Pages/Index.razor
+++ b/PosMultiplataforma/Pages/Index.razor
@@ -1,0 +1,5 @@
+@page "/"
+@layout MainLayout
+
+@* Panel principal del POS según la imagen de referencia *@
+<SalesPanel />

--- a/PosMultiplataforma/Platforms/Android/AndroidManifest.xml
+++ b/PosMultiplataforma/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/appicon"
+        android:label="PosMultiplataforma"
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name="com.microsoft.maui.MauiAppCompatActivity"
+            android:exported="true"
+            android:theme="@style/Maui.SplashTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/PosMultiplataforma/Platforms/Android/MainActivity.cs
+++ b/PosMultiplataforma/Platforms/Android/MainActivity.cs
@@ -1,0 +1,14 @@
+using Android.App;
+using Android.Content.PM;
+using Microsoft.Maui;
+
+namespace PosMultiplataforma;
+
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
+                           ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity
+{
+}

--- a/PosMultiplataforma/Platforms/Android/MainApplication.cs
+++ b/PosMultiplataforma/Platforms/Android/MainApplication.cs
@@ -1,0 +1,17 @@
+using System;
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+
+namespace PosMultiplataforma;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/PosMultiplataforma/Platforms/MacCatalyst/AppDelegate.cs
+++ b/PosMultiplataforma/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace PosMultiplataforma;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/PosMultiplataforma/Platforms/MacCatalyst/Program.cs
+++ b/PosMultiplataforma/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace PosMultiplataforma;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/PosMultiplataforma/Platforms/Windows/App.xaml
+++ b/PosMultiplataforma/Platforms/Windows/App.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="PosMultiplataforma.WinUI.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/PosMultiplataforma/Platforms/Windows/App.xaml.cs
+++ b/PosMultiplataforma/Platforms/Windows/App.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace PosMultiplataforma.WinUI;
+
+public partial class App : MauiWinUIApplication
+{
+    public App()
+    {
+        this.InitializeComponent();
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/PosMultiplataforma/Platforms/Windows/MainWindow.xaml
+++ b/PosMultiplataforma/Platforms/Windows/MainWindow.xaml
@@ -1,0 +1,6 @@
+<maui:MauiWinUIWindow
+    x:Class="PosMultiplataforma.WinUI.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui">
+</maui:MauiWinUIWindow>

--- a/PosMultiplataforma/Platforms/Windows/MainWindow.xaml.cs
+++ b/PosMultiplataforma/Platforms/Windows/MainWindow.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui;
+
+namespace PosMultiplataforma.WinUI;
+
+public partial class MainWindow : MauiWinUIWindow
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/PosMultiplataforma/Platforms/Windows/Package.appxmanifest
+++ b/PosMultiplataforma/Platforms/Windows/Package.appxmanifest
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+  <Identity Name="com.posmultiplataforma.app" Publisher="CN=PosMultiplataforma" Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>PosMultiplataforma POS</DisplayName>
+    <PublisherDisplayName>PosMultiplataforma</PublisherDisplayName>
+    <Logo>Assets\\Square150x150Logo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="PosMultiplataforma.WinUI.App">
+      <uap:VisualElements
+        DisplayName="PosMultiplataforma POS"
+        Description="Interfaz de Punto de Venta"
+        BackgroundColor="#FFFFFF"
+        Square150x150Logo="Assets\\Square150x150Logo.png"
+        Square44x44Logo="Assets\\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\\Wide310x150Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+</Package>

--- a/PosMultiplataforma/Platforms/iOS/AppDelegate.cs
+++ b/PosMultiplataforma/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace PosMultiplataforma;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/PosMultiplataforma/Platforms/iOS/Program.cs
+++ b/PosMultiplataforma/Platforms/iOS/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace PosMultiplataforma;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/PosMultiplataforma/PosMultiplataforma.csproj
+++ b/PosMultiplataforma/PosMultiplataforma.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PosMultiplataforma</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <ApplicationTitle>PosMultiplataforma POS</ApplicationTitle>
+    <ApplicationId>com.posmultiplataforma.app</ApplicationId>
+    <ApplicationIdGuid>e4c447d3-87af-4a64-8be2-5f803a022b7c</ApplicationIdGuid>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiXaml Include="App.xaml" />
+    <MauiXaml Include="MainPage.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiAsset Include="wwwroot\\**" LogicalName="wwwroot\\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-preview.6.8842" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-preview.6.8842" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0-preview.6.8842" />
+  </ItemGroup>
+</Project>

--- a/PosMultiplataforma/Shared/MainLayout.razor
+++ b/PosMultiplataforma/Shared/MainLayout.razor
@@ -1,0 +1,16 @@
+@inherits LayoutComponentBase
+
+@* Estructura general del POS según la imagen de referencia *@
+<div class="app-shell">
+    <header class="app-shell__header">
+        <TopBar />
+    </header>
+    <div class="app-shell__body">
+        <aside class="app-shell__sidebar">
+            <SideMenu />
+        </aside>
+        <main class="app-shell__main">
+            @Body
+        </main>
+    </div>
+</div>

--- a/PosMultiplataforma/Shared/SalesPanel.razor
+++ b/PosMultiplataforma/Shared/SalesPanel.razor
@@ -1,0 +1,173 @@
+@* Panel de ventas principal inspirado en la sección central de la imagen *@
+<div class="sales-panel">
+    <div class="sales-panel__layout">
+        <div class="sales-panel__left">
+            @* Tarjeta de información de caja como en la parte superior izquierda *@
+            <section class="sales-card sales-card--accent">
+                <div class="sales-card__header">Caja 01</div>
+                <div class="sales-card__body">
+                    <p class="sales-card__title">Turno matutino</p>
+                    <p class="sales-card__text">Supervisor: Ana Fernández</p>
+                    <p class="sales-card__text">Documento activo: Boleta electrónica</p>
+                </div>
+            </section>
+
+            @* Detalle de producto mostrado en la columna izquierda de la imagen *@
+            <section class="sales-card sales-card--product">
+                <div class="sales-card__header">Detalle de producto</div>
+                <div class="sales-card__body sales-card__body--product">
+                    <div class="product-preview">
+                        <div class="product-preview__bottle"></div>
+                    </div>
+                    <div class="product-preview__info">
+                        <h2 class="product-preview__name">Coca Cola 2.5 LTS desechable</h2>
+                        <p class="product-preview__code">SKU: 7801005543554</p>
+                        <p class="product-preview__price">$2.190</p>
+                    </div>
+                </div>
+            </section>
+
+            @* Área para ingresar códigos como en la referencia *@
+            <section class="sales-card sales-card--input">
+                <div class="sales-card__header">Ingresar código</div>
+                <div class="sales-card__body sales-card__body--input">
+                    <input class="sales-input" placeholder="Escanea o escribe el código de barras" />
+                    <button class="sales-button sales-button--primary">Agregar producto</button>
+                </div>
+            </section>
+
+            @* Selección de tipo de documento en la parte inferior izquierda *@
+            <section class="sales-card sales-card--document">
+                <div class="sales-card__header">Tipo de documento</div>
+                <div class="sales-card__body sales-card__body--document">
+                    <label class="sales-radio">
+                        <input type="radio" name="documentType" checked />
+                        <span>Boleta electrónica</span>
+                    </label>
+                    <label class="sales-radio">
+                        <input type="radio" name="documentType" />
+                        <span>Factura electrónica</span>
+                    </label>
+                    <label class="sales-radio">
+                        <input type="radio" name="documentType" />
+                        <span>Nota de crédito</span>
+                    </label>
+                </div>
+            </section>
+        </div>
+
+        <div class="sales-panel__right">
+            @* Listado de productos como el panel superior derecho *@
+            <section class="sales-card sales-card--list">
+                <div class="sales-card__header">Productos disponibles</div>
+                <div class="sales-card__body sales-card__body--scroll">
+                    <table class="sales-table">
+                        <thead>
+                            <tr>
+                                <th>Código</th>
+                                <th>Producto</th>
+                                <th>Precio</th>
+                                <th>Stock</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>7801005543554</td>
+                                <td>Coca Cola 2.5 LTS desechable</td>
+                                <td>$2.190</td>
+                                <td>24</td>
+                            </tr>
+                            <tr>
+                                <td>7800954464552</td>
+                                <td>Producto número 2 con descripción</td>
+                                <td>$1.490</td>
+                                <td>15</td>
+                            </tr>
+                            <tr>
+                                <td>7800954464553</td>
+                                <td>Producto número 3 con descripción</td>
+                                <td>$3.290</td>
+                                <td>10</td>
+                            </tr>
+                            <tr>
+                                <td>7800954464554</td>
+                                <td>Producto número 4 con descripción</td>
+                                <td>$820</td>
+                                <td>55</td>
+                            </tr>
+                            <tr>
+                                <td>7800954464555</td>
+                                <td>Producto número 5 con descripción</td>
+                                <td>$2.650</td>
+                                <td>30</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            @* Detalle de venta del lado derecho inferior de la imagen *@
+            <section class="sales-card sales-card--cart">
+                <div class="sales-card__header">Detalle de venta</div>
+                <div class="sales-card__body sales-card__body--scroll">
+                    <table class="sales-table sales-table--compact">
+                        <thead>
+                            <tr>
+                                <th>Producto</th>
+                                <th>Cant.</th>
+                                <th>Precio</th>
+                                <th>Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Coca Cola 2.5 LTS desechable</td>
+                                <td>2</td>
+                                <td>$2.190</td>
+                                <td>$4.380</td>
+                            </tr>
+                            <tr>
+                                <td>Producto número 2 con descripción</td>
+                                <td>1</td>
+                                <td>$1.490</td>
+                                <td>$1.490</td>
+                            </tr>
+                            <tr>
+                                <td>Producto número 4 con descripción</td>
+                                <td>3</td>
+                                <td>$820</td>
+                                <td>$2.460</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            @* Totales y acciones como en la franja inferior derecha *@
+            <div class="sales-panel__footer">
+                <div class="sales-summary">
+                    <div class="sales-summary__row">
+                        <span>Subtotal:</span>
+                        <span>$6.151</span>
+                    </div>
+                    <div class="sales-summary__row">
+                        <span>Descuento:</span>
+                        <span>$-1.169</span>
+                    </div>
+                    <div class="sales-summary__row">
+                        <span>IVA:</span>
+                        <span>$1.338</span>
+                    </div>
+                </div>
+                <div class="sales-total">
+                    <div class="sales-total__label">Total a pagar</div>
+                    <div class="sales-total__value">$7.320</div>
+                    <div class="sales-total__actions">
+                        <button class="sales-button sales-button--success">Pagar</button>
+                        <button class="sales-button sales-button--danger">Cancelar venta</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/PosMultiplataforma/Shared/SideMenu.razor
+++ b/PosMultiplataforma/Shared/SideMenu.razor
@@ -1,0 +1,13 @@
+@* Menú lateral inspirado en la columna azul de la imagen *@
+<nav class="side-menu">
+    <div class="side-menu__brand">Menú</div>
+    <ul class="side-menu__list">
+        <li class="side-menu__item side-menu__item--active">Ventas</li>
+        <li class="side-menu__item">Productos</li>
+        <li class="side-menu__item">Clientes</li>
+        <li class="side-menu__item">Reportes</li>
+        <li class="side-menu__item">Configuración</li>
+        <li class="side-menu__item">Soporte</li>
+    </ul>
+    <div class="side-menu__footer">Sistema POS © 2025</div>
+</nav>

--- a/PosMultiplataforma/Shared/TopBar.razor
+++ b/PosMultiplataforma/Shared/TopBar.razor
@@ -1,0 +1,17 @@
+@* Barra superior según la imagen de referencia *@
+<div class="top-bar">
+    <div class="top-bar__left">
+        <div class="top-bar__title">CAJA 01</div>
+        <div class="top-bar__subtitle">Provisiones Menita POS</div>
+    </div>
+    <div class="top-bar__center">
+        <div class="top-bar__status">
+            <span class="top-bar__status-label">Turno:</span>
+            <span class="top-bar__status-value">29 Agosto 2025 - Pucón, Chile</span>
+        </div>
+    </div>
+    <div class="top-bar__right">
+        <span class="top-bar__user">Usuario activo: Cajero Principal</span>
+        <button class="top-bar__action">Cerrar sesión</button>
+    </div>
+</div>

--- a/PosMultiplataforma/_Imports.razor
+++ b/PosMultiplataforma/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using PosMultiplataforma
+@using PosMultiplataforma.Shared

--- a/PosMultiplataforma/wwwroot/css/main.css
+++ b/PosMultiplataforma/wwwroot/css/main.css
@@ -1,0 +1,538 @@
+:root {
+    --color-primary: #0067c5;
+    --color-primary-dark: #004b92;
+    --color-primary-light: #1fa0ff;
+    --color-background: #f2f6fc;
+    --color-surface: #ffffff;
+    --color-border: #d5e0ef;
+    --color-text: #1f2a3a;
+    --color-muted: #6c7a92;
+    --color-success: #00a86b;
+    --color-danger: #e15241;
+    --radius-large: 24px;
+    --radius-medium: 16px;
+    --radius-small: 12px;
+    --shadow-soft: 0 12px 24px rgba(0, 58, 105, 0.12);
+    --shadow-card: 0 6px 12px rgba(0, 58, 105, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    font-family: "Segoe UI", Roboto, sans-serif;
+    background: var(--color-background);
+    color: var(--color-text);
+    height: 100%;
+}
+
+body {
+    display: flex;
+    min-height: 100vh;
+}
+
+#app {
+    width: 100%;
+    height: 100%;
+}
+
+.app-shell {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: linear-gradient(145deg, #f7fbff 0%, #e6f1ff 100%);
+}
+
+.app-shell__header {
+    background: var(--color-surface);
+    padding: 24px 32px;
+    box-shadow: var(--shadow-soft);
+    z-index: 10;
+}
+
+.app-shell__body {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 24px;
+    padding: 24px;
+    overflow: hidden;
+}
+
+.app-shell__sidebar {
+    background: var(--color-primary);
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+    display: flex;
+}
+
+.app-shell__main {
+    background: transparent;
+    overflow: hidden;
+    display: flex;
+}
+
+/* Barra superior */
+.top-bar {
+    display: grid;
+    grid-template-columns: 320px 1fr auto;
+    align-items: center;
+    gap: 32px;
+    color: var(--color-text);
+}
+
+.top-bar__left {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.top-bar__title {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--color-primary-dark);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.top-bar__subtitle {
+    font-size: 16px;
+    color: var(--color-muted);
+}
+
+.top-bar__center {
+    display: flex;
+    justify-content: center;
+}
+
+.top-bar__status {
+    display: flex;
+    gap: 12px;
+    background: linear-gradient(90deg, rgba(0, 103, 197, 0.1), rgba(31, 160, 255, 0.15));
+    padding: 12px 18px;
+    border-radius: var(--radius-medium);
+    color: var(--color-primary-dark);
+    font-weight: 600;
+    box-shadow: inset 0 0 0 1px rgba(0, 103, 197, 0.15);
+}
+
+.top-bar__status-label {
+    opacity: 0.7;
+}
+
+.top-bar__right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.top-bar__user {
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.top-bar__action {
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(90deg, var(--color-primary-dark), var(--color-primary-light));
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 8px 16px rgba(0, 79, 146, 0.3);
+}
+
+/* Menú lateral */
+.side-menu {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 28px 20px;
+    color: white;
+    background: linear-gradient(180deg, var(--color-primary-dark) 0%, var(--color-primary) 45%, var(--color-primary-light) 100%);
+}
+
+.side-menu__brand {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 32px;
+    text-align: center;
+    opacity: 0.85;
+}
+
+.side-menu__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.side-menu__item {
+    padding: 14px 18px;
+    border-radius: var(--radius-medium);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.08);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.side-menu__item:hover {
+    background: rgba(255, 255, 255, 0.18);
+    transform: translateX(4px);
+}
+
+.side-menu__item--active {
+    background: rgba(255, 255, 255, 0.35);
+    color: var(--color-primary-dark);
+}
+
+.side-menu__footer {
+    margin-top: auto;
+    text-align: center;
+    font-size: 12px;
+    opacity: 0.8;
+    letter-spacing: 0.1em;
+}
+
+/* Panel de ventas */
+.sales-panel {
+    flex: 1;
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 28px;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+}
+
+.sales-panel__layout {
+    display: grid;
+    grid-template-columns: 420px 1fr;
+    gap: 24px;
+    width: 100%;
+}
+
+.sales-panel__left,
+.sales-panel__right {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.sales-panel__left {
+    max-width: 420px;
+}
+
+.sales-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-medium);
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.sales-card__header {
+    padding: 18px 22px;
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    color: var(--color-primary-dark);
+    background: linear-gradient(90deg, rgba(0, 103, 197, 0.12), rgba(31, 160, 255, 0.05));
+}
+
+.sales-card__body {
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sales-card--accent .sales-card__header {
+    background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-light) 100%);
+    color: white;
+}
+
+.sales-card--accent .sales-card__title {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.sales-card__text {
+    margin: 0;
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.sales-card--product .sales-card__body {
+    flex-direction: row;
+    gap: 18px;
+    align-items: center;
+}
+
+.product-preview {
+    width: 130px;
+    height: 220px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(0, 103, 197, 0.1), rgba(0, 103, 197, 0.2));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.product-preview__bottle {
+    width: 70px;
+    height: 180px;
+    border-radius: 35px 35px 28px 28px;
+    background: linear-gradient(180deg, #c62828 0%, #8e0000 70%, #480000 100%);
+    position: relative;
+}
+
+.product-preview__bottle::before {
+    content: "";
+    position: absolute;
+    top: -18px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 22px;
+    height: 22px;
+    border-radius: 6px 6px 4px 4px;
+    background: #f4f4f4;
+}
+
+.product-preview__info {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.product-preview__name {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--color-primary-dark);
+    text-transform: uppercase;
+}
+
+.product-preview__code {
+    margin: 0;
+    font-size: 14px;
+    color: var(--color-muted);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.product-preview__price {
+    margin: 0;
+    font-size: 28px;
+    font-weight: 800;
+    color: var(--color-primary);
+}
+
+.sales-card__body--input {
+    flex-direction: row;
+    gap: 12px;
+}
+
+.sales-input {
+    flex: 1;
+    padding: 14px 16px;
+    border-radius: var(--radius-small);
+    border: 2px solid var(--color-border);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text);
+    background: #f8fbff;
+}
+
+.sales-button {
+    border: none;
+    padding: 14px 20px;
+    border-radius: var(--radius-small);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sales-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(0, 79, 146, 0.2);
+}
+
+.sales-button--primary {
+    background: linear-gradient(90deg, var(--color-primary), var(--color-primary-light));
+    color: white;
+}
+
+.sales-button--success {
+    background: linear-gradient(90deg, #00a86b, #00c07f);
+    color: white;
+    min-width: 140px;
+}
+
+.sales-button--danger {
+    background: linear-gradient(90deg, #ff6b6b, #ff3b3b);
+    color: white;
+}
+
+.sales-card__body--document {
+    gap: 10px;
+}
+
+.sales-radio {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.sales-card--list,
+.sales-card--cart {
+    flex: 1;
+}
+
+.sales-card__body--scroll {
+    overflow: auto;
+    max-height: 240px;
+}
+
+.sales-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.sales-table th {
+    text-align: left;
+    padding: 12px 16px;
+    background: rgba(0, 103, 197, 0.08);
+    color: var(--color-primary-dark);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.sales-table td {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-text);
+}
+
+.sales-table--compact th,
+.sales-table--compact td {
+    padding: 10px 14px;
+}
+
+.sales-panel__footer {
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 24px;
+    align-items: stretch;
+}
+
+.sales-summary {
+    background: linear-gradient(180deg, rgba(0, 103, 197, 0.08), rgba(0, 103, 197, 0.03));
+    border-radius: var(--radius-medium);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    box-shadow: inset 0 0 0 1px rgba(0, 103, 197, 0.1);
+}
+
+.sales-summary__row {
+    display: flex;
+    justify-content: space-between;
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.sales-total {
+    background: linear-gradient(90deg, var(--color-primary-dark), var(--color-primary-light));
+    border-radius: var(--radius-medium);
+    padding: 24px 28px;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: var(--shadow-soft);
+}
+
+.sales-total__label {
+    font-size: 18px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    opacity: 0.85;
+}
+
+.sales-total__value {
+    font-size: 44px;
+    font-weight: 800;
+}
+
+.sales-total__actions {
+    display: flex;
+    gap: 12px;
+}
+
+/* Responsividad */
+@media (max-width: 1280px) {
+    .app-shell__body {
+        grid-template-columns: 220px 1fr;
+        gap: 16px;
+    }
+
+    .sales-panel__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .sales-panel__left {
+        max-width: 100%;
+    }
+
+    .sales-panel__footer {
+        grid-template-columns: 1fr;
+    }
+
+    .sales-total__actions {
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 960px) {
+    .top-bar {
+        grid-template-columns: 1fr;
+        gap: 16px;
+        text-align: center;
+    }
+
+    .top-bar__right {
+        justify-content: center;
+    }
+
+    .app-shell__body {
+        grid-template-columns: 1fr;
+    }
+
+    .app-shell__sidebar {
+        display: none;
+    }
+
+    .sales-panel {
+        padding: 18px;
+    }
+}

--- a/PosMultiplataforma/wwwroot/index.html
+++ b/PosMultiplataforma/wwwroot/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>POS Multiplataforma</title>
+    <link rel="stylesheet" href="css/main.css" />
+</head>
+<body>
+    <div id="app">Cargando...</div>
+    <script src="_framework/blazor.webview.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold a .NET MAUI Blazor Hybrid solution targeting .NET 9 for the POS experience
- implement TopBar, SideMenu, MainLayout, and SalesPanel components mirroring the provided reference layout
- add responsive styling in wwwroot/css/main.css to reproduce the POS visual design without external assets

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e52398d8a0832594474b0a12f45f35